### PR TITLE
Include unistd.h for 'close'

### DIFF
--- a/bless.c
+++ b/bless.c
@@ -25,6 +25,7 @@
 #include <sys/ioctl.h>
 #include <sys/vfs.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #define HFSPLUS_IOC_BLESS _IO('h', 0x80)
 


### PR DESCRIPTION
Fixes warnings about implicit declaration of `close`.

Clang:

```
bless.c:62:2: warning: implicit declaration of function 'close' is invalid in C99 [-Wimplicit-function-declaration]
        close(fd);
        ^
1 warning generated.
```

GCC:

```
bless.c: In function ‘main’:
bless.c:62:2: warning: implicit declaration of function ‘close’; did you mean ‘pclose’? [-Wimplicit-function-declaration]
  close(fd);
  ^~~~~
  pclose
```